### PR TITLE
fixing minors issues not solved before today

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -93,7 +93,7 @@ bool addVar(varList_t *varList, char *name, char *value, long lineNb, asm_error_
             return true;
         }
     }
-    unknowError("On variable declaration", errData);
+    unknownError("On variable declaration", errData);
     return false;
 }
 
@@ -197,7 +197,7 @@ int addLabel(labelList_t *labelList, char *name, long nodeId, long lineNb, asm_e
         }
     }
 
-    unknowError("On label declaration", errData);
+    unknownError("On label declaration", errData);
     return -1;
 }
 

--- a/src/binExporter.c
+++ b/src/binExporter.c
@@ -17,7 +17,7 @@ void exportToBin(instList_t *nodeList, char *filename, asm_error_t *errData){
 
     // Check if the file was opened
     if(file == NULL){
-        unknowError("File cannot be opened", errData);
+        unknownError("File cannot be opened", errData);
         return;
     }
     instNode_t *node = nodeList->head;

--- a/src/builder.c
+++ b/src/builder.c
@@ -66,7 +66,7 @@ void buildNode(instNode_t *node, varList_t *varList, labelList_t *labeList, asm_
             node->isBuilt = true;
             break;
         default:
-            unknowError("Operation code not found during build", errData);
+            unknownError("Operation code not found during build", errData);
             node->isBuilt = true;
             break;
     }
@@ -341,7 +341,7 @@ void buildMov(instNode_t *node, varList_t *varList, asm_error_t *errData){
             return;
         }
     }
-    unknowError("Mov build is failed", errData);
+    unknownError("Mov build is failed", errData);
 
     return;
 }
@@ -441,7 +441,7 @@ void buildOperation(instNode_t *node, varList_t *varList, asm_error_t *errData){
 
         return;
     }
-    unknowError("Operation connot be built", errData);
+    unknownError("Operation cannot be built", errData);
     return;
 }
 

--- a/src/debug.c
+++ b/src/debug.c
@@ -24,7 +24,7 @@ void printAst(instList_t *nodeList, asm_error_t *errData){
 void printNodeData(instNode_t *node, asm_error_t *errData){
     FILE *file = fopen(logFile, "ab");
     if(file == NULL){
-        unknowError("File cannot be opened", errData);
+        unknownError("File cannot be opened", errData);
         exit(EXIT_FAILURE);
     }
     // Get current time

--- a/src/error.c
+++ b/src/error.c
@@ -435,7 +435,7 @@ void errorIntCodeNotSupported(long code, asm_error_t *errData){
     displayError(errType, errDetails, NULL, errorFile, errData);
 }
 
-void unknowError(char *details, asm_error_t *errData){
+void unknownError(char *details, asm_error_t *errData){
     char *errType = "Unknown Error";
     displayError(errType, details, NULL, errorFile, errData);
 }

--- a/src/error.h
+++ b/src/error.h
@@ -339,7 +339,7 @@ void errorIntCodeNotSupported(long code, asm_error_t *errData);
         details: Details about the error
         errData: Error history
 */
-void unknowError(char *details, asm_error_t *errData);
+void unknownError(char *details, asm_error_t *errData);
 
 /*
     Display error messages for binary conversion issues


### PR DESCRIPTION
Version 1.1.2

This pull request addresses a series of typographical errors in the error handling functions across several source files. The changes correct the spelling of the function name and the error message from "unknowError" to "unknownError".

The most important changes include:

Typographical error corrections:

* [`src/ast.c`](diffhunk://#diff-0f0c479263e27b6ba44eecdfaddac20d3a966196da6a1c6fc25327a0093437caL96-R96): Corrected "unknowError" to "unknownError" in the `addVar` and `addLabel` functions. [[1]](diffhunk://#diff-0f0c479263e27b6ba44eecdfaddac20d3a966196da6a1c6fc25327a0093437caL96-R96) [[2]](diffhunk://#diff-0f0c479263e27b6ba44eecdfaddac20d3a966196da6a1c6fc25327a0093437caL200-R200)
* [`src/binExporter.c`](diffhunk://#diff-d677cd2bd9f9d26b639fb9d163891862624655fab90c70872b20baed4054298fL20-R20): Corrected "unknowError" to "unknownError" in the `exportToBin` function.
* [`src/builder.c`](diffhunk://#diff-fd7337dab149f4fbb80557c3cfe8e4e052cb9e1cd65bf17477061334a72fc9d3L69-R69): Corrected "unknowError" to "unknownError" in the `buildNode`, `buildMov`, and `buildOperation` functions. [[1]](diffhunk://#diff-fd7337dab149f4fbb80557c3cfe8e4e052cb9e1cd65bf17477061334a72fc9d3L69-R69) [[2]](diffhunk://#diff-fd7337dab149f4fbb80557c3cfe8e4e052cb9e1cd65bf17477061334a72fc9d3L344-R344) [[3]](diffhunk://#diff-fd7337dab149f4fbb80557c3cfe8e4e052cb9e1cd65bf17477061334a72fc9d3L444-R444)
* [`src/debug.c`](diffhunk://#diff-9450d43dd0c51c7b781f01100a2d37e9ef1903d6a16fcf51be40b03f3d8aed38L27-R27): Corrected "unknowError" to "unknownError" in the `printAst` function.
* `src/error.c` and `src/error.h`: Corrected "unknowError" to "unknownError" in the `unknownError` function and its declaration. [[1]](diffhunk://#diff-0785f4cf8a2cc06d90d511879d9b43ff9f69858fceb83bc13a5f78bd8b3a9187L438-R438) [[2]](diffhunk://#diff-813335d319e76e48a24af787257fc92e57f8e461aa07904b98d96bc2b07863b8L342-R342)

close #100 , #94