### PR TITLE
updating the IAT2 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ It will generate a bin folder containing our runners to use it refers to [How do
 If you want to contribute please take a look to [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## 🗃️ Versions
-- **Latest :** 1.1.1
-- **Current :** 1.1.1
+- **Latest :** 1.1.2
+- **Current :** 1.1.2
 - Versions List : [Cliquer pour afficher](https://github.com/algosup/2023-2024-project-3-virtual-processor-team-2/tags)
 
 ## ⚖️ License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,18 +6,19 @@ These versions are currently updated and can include security patches:
 
 | Version     | Supported          |
 | ----------- | ------------------ |
-| > 1.1.1     | :white_check_mark: |
+| > 1.1.2     | :white_check_mark: |
+| &emsp;1.1.1 | :white_check_mark: |
 | &emsp;1.1.0 | :white_check_mark: |
 | &emsp;1.0.0 | :white_check_mark: |
-| &emsp;0.5.0 | :x: |
-| &emsp;0.4.0 | :x: |
-| &emsp;0.3.0 | :x: |
-| &emsp;0.2.0 | :x: |
-| &emsp;0.1.1 | :x: |
-| &emsp;0.0.4 | :x: |
-| &emsp;0.0.3 | :x: |
-| &emsp;0.0.2 | :x: |
-| &emsp;0.0.1 | :x: |
+| &emsp;0.5.0 | :x:                |
+| &emsp;0.4.0 | :x:                |
+| &emsp;0.3.0 | :x:                |
+| &emsp;0.2.0 | :x:                |
+| &emsp;0.1.1 | :x:                |
+| &emsp;0.0.4 | :x:                |
+| &emsp;0.0.3 | :x:                |
+| &emsp;0.0.2 | :x:                |
+| &emsp;0.0.1 | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
This pull request includes updates to the version numbers in the documentation files to reflect the latest release.

Version updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R111): Updated the "Latest" and "Current" version numbers from `1.1.1` to `1.1.2`.
* [`SECURITY.md`](diffhunk://#diff-f6ed156e4bf5c791680662464b94ea5d753f219ee816b385f67870e2c0d7d4c7L9-R10): Added version `1.1.2` to the supported versions list and retained version `1.1.1` as supported.